### PR TITLE
Deprecation API v1 as of May 1st, 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Ansible Role: exoscale
+
+:warning: **DEPRECATED:** Exoscale will no longer support the Cloudstack API after May 1, 2024.
+[See Announcement](https://changelog.exoscale.com/en/deprecation-api-v1-as-of-may-1st-2024-uVYHUVZ3).
+
 [![Build Status](https://travis-ci.com/arillso/ansible.exoscale.svg?branch=master)](https://travis-ci.com/arillso/ansible.exoscale)
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg?style=popout-square)](https://sbaerlo.ch/licence)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-arillso.exoscale-blue.svg?style=popout-square)](https://galaxy.ansible.com/arillso/exoscale)


### PR DESCRIPTION
Hello @resmo!

Exoscale announced the deprecation of the [Cloudstack API after May 1, 2024](https://changelog.exoscale.com/en/deprecation-api-v1-as-of-may-1st-2024-uVYHUVZ3).
This will make this role obsolete, which will stop working after this given date.
The proposal is to add a note of warning to inform future users.